### PR TITLE
expose any additional params passed out of the oauth responses

### DIFF
--- a/TinyOAuth1/AccessTokenInfo.cs
+++ b/TinyOAuth1/AccessTokenInfo.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+
 namespace TinyOAuth1
 {
 	public class AccessTokenInfo
 	{
 		public string AccessToken { get; set; }
 		public string AccessTokenSecret { get; set; }
+		public IDictionary<string, string> AdditionalParams { get; set; }
 	}
 }

--- a/TinyOAuth1/RequestTokenInfo.cs
+++ b/TinyOAuth1/RequestTokenInfo.cs
@@ -1,8 +1,11 @@
-﻿namespace TinyOAuth1
+﻿using System.Collections.Generic;
+
+namespace TinyOAuth1
 {
 	public class RequestTokenInfo
 	{
 		public string RequestToken { get; set; }
 		public string RequestTokenSecret { get; set; }
+		public IDictionary<string, string> AdditionalParams { get; set; }
 	}
 }

--- a/TinyOAuth1/TinyOAuth.cs
+++ b/TinyOAuth1/TinyOAuth.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
+using TinyOAuth1.Utility;
 
 namespace TinyOAuth1
 {
@@ -95,7 +98,7 @@ namespace TinyOAuth1
 			Added to the URLs in the query part (as defined by [RFC3986] section 3).
 			In addition to these defined methods, future extensions may describe alternate methods for sending the OAuth Protocol Parameters. The methods for sending other request parameters are left undefined, but SHOULD NOT use the OAuth HTTP Authorization Scheme header.
 
-      		*/
+	  		*/
 
 			/* 5.4.1.  Authorization Header
 
@@ -267,30 +270,19 @@ namespace TinyOAuth1
 
 			if (!string.IsNullOrEmpty(responseText))
 			{
-				string oauthToken = null;
-				string oauthTokenSecret = null;
-				var keyValPairs = responseText.Split('&');
+				var keyValPairs = HttpUtility.ParseQueryString(responseText);
 
-				for (var i = 0; i < keyValPairs.Length; i++)
-				{
-					var splits = keyValPairs[i].Split('=');
-					switch (splits[0])
-					{
-						case "oauth_token":
-							oauthToken = splits[1];
-							break;
-						case "oauth_token_secret":
-							oauthTokenSecret = splits[1];
-							break;
-					}
-				}
+				var oauthToken = keyValPairs.GetValues("oauth_token")?.SingleOrDefault();
+				var oauthTokenSecret = keyValPairs.GetValues("oauth_token_secret")?.SingleOrDefault();
 
 				return new AccessTokenInfo
 				{
 					AccessToken = oauthToken,
-					AccessTokenSecret = oauthTokenSecret
+					AccessTokenSecret = oauthTokenSecret,
+					AdditionalParams = keyValPairs.ToDictionary()
 				};
 			}
+
 			throw new Exception("Empty response text when getting the access token");
 		}
 
@@ -342,36 +334,21 @@ namespace TinyOAuth1
 				//	oauth_token_secret:
 				//The Token Secret.
 
-				string oauthToken = null;
-				string oauthTokenSecret = null;
 				//string oauthAuthorizeUrl = null;
 
-				var keyValPairs = responseText.Split('&');
+				var keyValPairs = HttpUtility.ParseQueryString(responseText);
 
-				for (var i = 0; i < keyValPairs.Length; i++)
-				{
-					var splits = keyValPairs[i].Split('=');
-					switch (splits[0])
-					{
-						case "oauth_token":
-							oauthToken = splits[1];
-							break;
-						case "oauth_token_secret":
-							oauthTokenSecret = splits[1];
-							break;
-							// TODO: Handle this one?
-							//case "xoauth_request_auth_url":
-							//	oauthAuthorizeUrl = splits[1];
-							//	break;
-					}
-				}
+				var oauthToken = keyValPairs.GetValues("oauth_token")?.SingleOrDefault();
+				var oauthTokenSecret = keyValPairs.GetValues("oauth_token_secret")?.SingleOrDefault();
 
 				return new RequestTokenInfo
 				{
 					RequestToken = oauthToken,
-					RequestTokenSecret = oauthTokenSecret
+					RequestTokenSecret = oauthTokenSecret,
+					AdditionalParams = keyValPairs.ToDictionary()
 				};
 			}
+
 			throw new Exception("Empty response text when getting the request token");
 		}
 

--- a/TinyOAuth1/TinyOAuth1.csproj
+++ b/TinyOAuth1/TinyOAuth1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -12,13 +12,13 @@
     <Copyright>Copyright 2017 © Johan Otterud. All rights reserved.</Copyright>
     <PackageTags>oauth 1.0a oauth1 authorization 1.0 authentication</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Company />
     <PackageLicenseUrl>https://raw.githubusercontent.com/johot/TinyOAuth1/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/johot/TinyOAuth1</PackageProjectUrl>
     <RepositoryUrl></RepositoryUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     
   </PropertyGroup>
 

--- a/TinyOAuth1/Utility/NameValueCollectionExtensions.cs
+++ b/TinyOAuth1/Utility/NameValueCollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace TinyOAuth1.Utility
+{
+	internal static class NameValueCollectionExtensions
+	{
+		internal static IDictionary<string, string> ToDictionary(this NameValueCollection col)
+		{
+			var dict = new Dictionary<string, string>();
+			foreach (var k in col.AllKeys)
+			{
+				dict.Add(k, col[k]);
+			}
+			return dict;
+		}
+	}
+}


### PR DESCRIPTION
I love the simplicity of this library, but I have been working with some APIs that implement OAuth1 in a non standard way and require either capturing extra information from the response, or passing extra information in the requests.

Initially it would be really good if I could get these params out of the responses.

Happy to iterate over this suggestion till it suits everyone.